### PR TITLE
Centered replies

### DIFF
--- a/mimi-app/src/main/java/com/emogoth/android/phone/mimi/dialog/RepliesDialog.kt
+++ b/mimi-app/src/main/java/com/emogoth/android/phone/mimi/dialog/RepliesDialog.kt
@@ -142,7 +142,7 @@ class RepliesDialog : DialogFragment(), GoToPostListener {
     override fun onResume() {
         super.onResume()
         dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        dialog?.window?.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.TOP)
+        dialog?.window?.setGravity(Gravity.CENTER)
     }
 
     fun close() {


### PR DESCRIPTION
Reaching to the top of a tall screen to use the reply dialog is annoying, this patch moves the replies to the center (like in the layout files)